### PR TITLE
Remove implicit any

### DIFF
--- a/lib/modem.d.ts
+++ b/lib/modem.d.ts
@@ -48,7 +48,7 @@ class Modem implements Modem.SocketOptions, Modem.HostOptions {
      * @param onFinished    Callback which will be called when stream ends.
      * @param [onProgress]  Callback which will be called multiple times to report job progress.
      */
-    public followProgress<T>(stream: NodeJS.ReadableStream, onFinished: Modem.Callback<T>, onProgress?: (evt: any) => void);
+    public followProgress<T>(stream: NodeJS.ReadableStream, onFinished: Modem.Callback<T>, onProgress?: (evt: any) => void): void;
 
     /**
      * Builds Query String parameters from Object.


### PR DESCRIPTION
When trying to compile a project that needs this type and is configured
with `noImplicitAny`, it fails with error:

```
'followProgress', which lacks return-type annotation, implicitly has an
'any' return type.
```

This fixes it.